### PR TITLE
Updated for 1.20 and 1.20.1 paper server.

### DIFF
--- a/src/main/java/cx/rain/mc/diggus_maximus_bukkit/nms/ExcavatorFactory.java
+++ b/src/main/java/cx/rain/mc/diggus_maximus_bukkit/nms/ExcavatorFactory.java
@@ -10,11 +10,13 @@ public class ExcavatorFactory {
     static {
         var bukkitVersion = Bukkit.getBukkitVersion();
         switch (bukkitVersion) {
+            case "1.20-R0.1-SNAPSHOT":
+            case "1.20.1-R0.1-SNAPSHOT":
             case "1.19.4-R0.1-SNAPSHOT":
                 EXCAVATOR = new ExcavatorImplV1_19_4();
                 break;
             default:
-                throw new RuntimeException("Not supported version!");
+                throw new RuntimeException("Not supported version:" + bukkitVersion);
         }
     }
 


### PR DESCRIPTION
That's easier than expected.
Tested with ViaFabric and DiggusMaximus on 1.19.4 on a Paper 1.20.1 server.
It's also expected to work with any other server with bukkit plugin support but it's untested yet.
Meow~